### PR TITLE
check linear invariants for ADP problem

### DIFF
--- a/nusslein_vsrp/ADP_Julia.ipynb
+++ b/nusslein_vsrp/ADP_Julia.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using LinearAlgebra\n",
+    "using SymPy\n",
+    "\n",
+    "u = [symbols(\"u_$i\", real=true) for i in 1:4]\n",
+    "u2 = u[2]\n",
+    "u3 = u[3]\n",
+    "u4 = u[4]\n",
+    "u1u2 = u[1] * u[2] / (1//100 + u[1])\n",
+    "eu3 = symbols(\"eu_3\", real=true)\n",
+    "terms = [u2, u3, u4, u1u2, eu3]\n",
+    "\n",
+    "mat = Sym[\n",
+    "    1//100 1//100 3//1000 -1 0\n",
+    "    -6//100 0 0 1 -1\n",
+    "    0 -3//100 0 0 1\n",
+    "    5//100 2//100 -3//1000 0 0\n",
+    "]\n",
+    "mat * terms\n",
+    "\n",
+    "transpose(mat).nullspace()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.4.1",
+   "language": "julia",
+   "name": "julia-1.4"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.4.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I've checked that only the sum of all components is a linear invariant of the diffusion-advection-reaction problem (when the sign in eq. (6.6d) is fixed). Hence, it would be nice to add the other example with two linear invariants @snuesslein has implemented.